### PR TITLE
panic if buf has len==0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,13 @@ impl<'a, T: Clone> CBuf<'a, T>
     ///
     /// Length (not capacity) will be used to store elements
     /// in the circular buffer.
+    ///
+    /// panics if buf.len() == 0
     pub fn new(buf: &'a mut [T]) -> CBuf<T> {
         debug_assert!(buf.len() < CBUF_DATA_BIT);
+        if buf.len() == 0 {
+            panic!("len==0")
+        }
 
         CBuf {
             buf: buf,


### PR DESCRIPTION
I hit this bug during development. After looking through the code, I now realize it is impossible for the current archetecture to correctly use 0 len buffers.

At first I though we could just set self.head != self.tail in the case that len==0, however:

`is_empty` asks `self.head == self.tail` and `is_full` asks `self.head ^ self.tail) == CBUF_DATA_BIT`

So we have to break either `get` or `put`.

We could also put in a logical check before one or the other, but I am not willing to have performance suffer for such a special case.
